### PR TITLE
booty: stop and stop-all commands

### DIFF
--- a/cmd/stop-all.go
+++ b/cmd/stop-all.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.amplifyedge.org/booty-v2/dep"
+)
+
+// stops all services under the hood
+func StopAllCommand(e dep.Executor) *cobra.Command {
+	stopCmd := &cobra.Command{Use: "stop-all", DisableFlagParsing: true, Short: "stop-all components that can be run as service."}
+	stopCmd.DisableFlagParsing = true
+	stopCmd.Flags().SetInterspersed(true)
+	stopCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return e.StopAll()
+	}
+	return stopCmd
+}
+
+// stops service under the hood
+func StopCommand(e dep.Executor) *cobra.Command {
+	stopCmd := &cobra.Command{Use: "stop <service_name>", DisableFlagParsing: true, Short: "stop components.", Args: cobra.ExactArgs(1)}
+	stopCmd.DisableFlagParsing = true
+	stopCmd.Flags().SetInterspersed(true)
+	stopCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		return e.Stop(args[0])
+	}
+	return stopCmd
+}

--- a/dep/interfaces.go
+++ b/dep/interfaces.go
@@ -16,7 +16,9 @@ type Executor interface {
 	AllInstalledComponents() ([]byte, error) // list all installed components
 	DownloadAll() error                      // fetch all components
 	Run(name string, args ...string) error
-	RunAll() error                      // run all service components
+	RunAll() error // run all service components
+	Stop(name string) error
+	StopAll() error
 	Install(name, version string) error // installs a single component by its name
 	InstallAll() error                  // install all components
 	Uninstall(name string) error        // uninstalls a component

--- a/dep/orchestrator/makefiles/flu.mk
+++ b/dep/orchestrator/makefiles/flu.mk
@@ -1,5 +1,11 @@
 # flu utils
 
+SOURCE_PROTOC :=
+ifeq ($(OS),Windows_NT)
+	SOURCE_PROTOC:=
+else
+	SOURCE_PROTOC:=export PATH=$$HOME/.pub-cache/bin:$$PATH
+endif
 
 current_dir = $(shell pwd)
 
@@ -9,6 +15,7 @@ FLU_LIB_FSPATH = $(PWD)/$(FLU_LIB_NAME)
 FLU_SAMPLE_NAME = ???
 FLU_SAMPLE_FSPATH = $(PWD)/$(FLU_SAMPLE_NAME)
 
+TOOL_LANG_BIN_NAME = booty lang
 
 ## Prints the flutter settings
 flu-print:
@@ -31,6 +38,9 @@ flu-print:
 ## Configures flutter to be on right channel.
 flu-config:
 	flutter channel beta
+	dart pub global activate protoc_plugin
+	$(SOURCE_PROTOC)
+	flutter config --enable-web
 	flutter upgrade --force
 
 ## Updates flutter dependencies.
@@ -58,7 +68,6 @@ flu-test:
 
 ## Runs Flutter Web.
 flu-web-run:
-	flutter config --enable-web
 	cd $(FLU_SAMPLE_FSPATH) && flutter run -d chrome
 
 ## Runs Flutter Web in release mode

--- a/dep/orchestrator/orchestrate.go
+++ b/dep/orchestrator/orchestrate.go
@@ -117,6 +117,8 @@ func (o *Orchestrator) Command() *cobra.Command {
 		cmd.UpdateAllCommand(o, o),
 		cmd.AgentCommand(o, o),
 		cmd.RunAllCommand(o),
+		cmd.StopAllCommand(o),
+		cmd.StopCommand(o),
 		cmd.ListAllCommand(o),
 		// here we exported all the internal tools we might need (bs-crypt, bs-lang, etc)
 		sharedCmd.EncryptCmd(),
@@ -216,6 +218,25 @@ func dlErr(c dep.Component) func(err error) error {
 func (o *Orchestrator) Run(name string, args ...string) error {
 	comp := o.Component(name)
 	return comp.Run(args...)
+}
+
+func (o *Orchestrator) Stop(name string) error {
+	c := o.Component(name)
+	if c == nil {
+		return nil
+	}
+	return c.RunStop()
+}
+
+func (o *Orchestrator) StopAll() error {
+	for _, c := range o.components {
+		if c.IsService() {
+			if err := c.RunStop(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (o *Orchestrator) Install(name, version string) error {


### PR DESCRIPTION
https://github.com/amplify-edge/booty/issues/52

- Added stop and stop-all command
- Add flutter pub global activate protoc_plugin and adds it to the flu.mk